### PR TITLE
Use Yarn to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Convert your project from [Bower](https://bower.io/) to [Yarn](https://yarnpkg.c
 ## Usage
 
 ```
-npm install -g bower-away
+yarn global add bower-away
 bower-away # listen and repeat!
 ```
 


### PR DESCRIPTION
Since you're already requiring the usage of Yarn, you may as well install bower-away itself using Yarn.